### PR TITLE
Export internal functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm-run-all build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "prepare": "npm run build",
     "test:unit": "prisma generate && jest --config jest.config.unit.js",
     "test:e2e": "./test/scripts/run-with-postgres.sh jest --config jest.config.e2e.js --runInBand",
     "test": "./test/scripts/run-with-postgres.sh jest --runInBand",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export * from "./lib/types";
 
-export { createSoftDeleteExtension } from "./lib/createSoftDeleteExtension";
+export {
+  getModelsMethods,
+  createSoftDeleteExtension,
+  softDeleteExtensionOperations,
+} from "./lib/createSoftDeleteExtension";


### PR DESCRIPTION
In our codebase we use multiple extensions that implement `$allModels.$allOperations`.
They need to be chained and work together so we need to access the internal functions.