### PR TITLE
chore: fix typechecking of test folder

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "exclude": ["test"]
+  "exclude": []
 }


### PR DESCRIPTION
Excluding the test folder from the base config means in-editor typechecking does not work in that folder as expected.

The builds are based on child ts-configs which exludes test as well so it does not affect the dist.