### PR TITLE
fix: allow override deleted field in findUnique

### DIFF
--- a/src/lib/helpers/createParams.ts
+++ b/src/lib/helpers/createParams.ts
@@ -211,7 +211,8 @@ export const createFindUniqueParams: CreateParams = (config, params) => {
         ...params.args,
         where: {
           ...params.args?.where,
-          [config.field]: config.createValue(false),
+          // allow overriding the deleted field in where
+          [config.field]: params.args?.where?.[config.field] || config.createValue(false),
         },
       },
     },
@@ -233,7 +234,8 @@ export const createFindUniqueOrThrowParams: CreateParams = (config, params) => {
         ...params.args,
         where: {
           ...params.args?.where,
-          [config.field]: config.createValue(false),
+          // allow overriding the deleted field in where
+          [config.field]: params.args?.where?.[config.field] || config.createValue(false),
         },
       },
     },

--- a/test/unit/findUnique.test.ts
+++ b/test/unit/findUnique.test.ts
@@ -58,6 +58,28 @@ describe("findUnique", () => {
     expect(client.user.findUnique).not.toHaveBeenCalled();
   });
 
+  it("allows explicitly querying for deleted records using findUnique", async () => {
+    const client = new MockClient();
+    const extendedClient = client.$extends(
+      createSoftDeleteExtension({
+        models: { User: true },
+      })
+    );
+
+    await extendedClient.user.findUnique({
+      where: { id: 1, deleted: true },
+    });
+
+    // params have not been modified
+    expect(client.user.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 1,
+        deleted: true,
+      },
+    });
+    expect(client.user.findUnique).not.toHaveBeenCalled();
+  });
+
   it("throws when trying to pass a findUnique where with a compound unique index field", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(

--- a/test/unit/findUniqueOrThrow.test.ts
+++ b/test/unit/findUniqueOrThrow.test.ts
@@ -58,6 +58,28 @@ describe("findUniqueOrThrow", () => {
     expect(client.user.findUniqueOrThrow).not.toHaveBeenCalled();
   });
 
+  it("allows explicitly querying for deleted records using findUniqueOrThrow", async () => {
+    const client = new MockClient();
+    const extendedClient = client.$extends(
+      createSoftDeleteExtension({
+        models: { User: true },
+      })
+    );
+
+    await extendedClient.user.findUniqueOrThrow({
+      where: { id: 1, deleted: true },
+    });
+
+    // params have not been modified
+    expect(client.user.findFirstOrThrow).toHaveBeenCalledWith({
+      where: {
+        id: 1,
+        deleted: true,
+      },
+    });
+    expect(client.user.findUniqueOrThrow).not.toHaveBeenCalled();
+  });
+
   it("does not modify findUniqueOrThrow to be a findFirstOrThrow when no args passed", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(


### PR DESCRIPTION
### Allow override deleted field in `findUnique` and `findUniqueOrThrow`

The existing `findFirst` and `findFirstOrThrow` already have this override logic:
```js
{
  ...
  where: {
    ...params.args?.where,
    // allow overriding the deleted field in where
    [config.field]:
      params.args?.where?.[config.field] || config.createValue(false),
  },
  ...
}
```

But `findUnique` and `findUniqueOrThrow` don't have it. The `findUnique` and  `findUniqueOrThrow` called `findFirst` and `findFirstOrThrow` internally but the override params not passed to the internal call.
This PR try to fix this issue.