### PR TITLE
fix: fluent api

### DIFF
--- a/src/lib/helpers/createParams.ts
+++ b/src/lib/helpers/createParams.ts
@@ -154,7 +154,10 @@ export const createUpsertParams: CreateParams = (_, params) => {
   return { params };
 };
 
-function validateFindUniqueParams(params: Params, config: ModelConfig): void {
+function validateFindUniqueParams(
+  params: Params,
+  config: ModelConfig
+): void {
   const uniqueIndexFields = uniqueIndexFieldsByModel[params.model || ""] || [];
   const uniqueIndexField = Object.keys(params.args?.where || {}).find((key) =>
     uniqueIndexFields.includes(key)

--- a/test/e2e/fluent.test.ts
+++ b/test/e2e/fluent.test.ts
@@ -1,0 +1,50 @@
+import { PrismaClient, Profile, User } from "@prisma/client";
+import faker from "faker";
+
+import { createSoftDeleteExtension } from "../../src";
+import client from "./client";
+
+describe("fluent", () => {
+  let testClient: any;
+  let profile: Profile;
+  let user: User;
+
+  beforeAll(async () => {
+    testClient = new PrismaClient();
+    testClient = testClient.$extends(
+      createSoftDeleteExtension({ models: { Comment: true, Profile: true } })
+    );
+
+    profile = await client.profile.create({
+      data: {
+        bio: "foo",
+      },
+    });
+    user = await client.user.create({
+      data: {
+        email: faker.internet.email(),
+        name: faker.name.findName(),
+        profileId: profile.id,
+      },
+    });
+  });
+  afterAll(async () => {
+    // disconnect test client
+    await testClient.$disconnect();
+
+    // delete user and related data
+    await client.user.update({
+      where: { id: user.id },
+      data: { profile: { delete: true } },
+    });
+    await client.user.delete({ where: { id: user.id } });
+  });
+
+  it("supports fluent API", async () => {
+    const userProfile = await testClient.user
+      .findFirst({ where: { id: user.id } })
+      .profile();
+
+    expect(userProfile).toEqual(profile);
+  });
+});

--- a/test/e2e/queries.test.ts
+++ b/test/e2e/queries.test.ts
@@ -365,12 +365,12 @@ describe("queries", () => {
     it("throws a useful error when invalid where is passed", async () => {
       // throws useful error when no where is passed
       await expect(() => testClient.user.findUnique()).rejects.toThrowError(
-        "Invalid `prisma.user.findUnique()` invocation"
+        "Invalid `testClient.user.findUnique()` invocation"
       );
 
       // throws useful error when empty where is passed
       await expect(() => testClient.user.findUnique({})).rejects.toThrowError(
-        "Invalid `prisma.user.findUnique()` invocation"
+        "Invalid `testClient.user.findUnique()` invocation"
       );
 
       // throws useful error when where is passed undefined unique fields
@@ -379,7 +379,7 @@ describe("queries", () => {
           where: { id: undefined },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUnique()` invocation"
+        "Invalid `testClient.user.findUnique()` invocation"
       );
 
       // throws useful error when where has defined non-unique fields
@@ -388,7 +388,7 @@ describe("queries", () => {
           where: { name: firstUser.name },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUnique()` invocation"
+        "Invalid `testClient.user.findUnique()` invocation"
       );
 
       // throws useful error when where has undefined compound unique index field
@@ -397,7 +397,7 @@ describe("queries", () => {
           where: { name_email: undefined },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUnique()` invocation"
+        "Invalid `testClient.user.findUnique()` invocation"
       );
 
       // throws useful error when where has undefined unique field and defined non-unique field
@@ -406,7 +406,7 @@ describe("queries", () => {
           where: { id: undefined, name: firstUser.name },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUnique()` invocation"
+        "Invalid `testClient.user.findUnique()` invocation"
       );
     });
 
@@ -447,14 +447,14 @@ describe("queries", () => {
       await expect(() =>
         testClient.user.findUniqueOrThrow()
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUniqueOrThrow()` invocation"
+        "Invalid `testClient.user.findUniqueOrThrow()` invocation"
       );
 
       // throws useful error when empty where is passed
       await expect(() =>
         testClient.user.findUniqueOrThrow({})
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUniqueOrThrow()` invocation"
+        "Invalid `testClient.user.findUniqueOrThrow()` invocation"
       );
 
       // throws useful error when where is passed undefined unique fields
@@ -463,7 +463,7 @@ describe("queries", () => {
           where: { id: undefined },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUniqueOrThrow()` invocation"
+        "Invalid `testClient.user.findUniqueOrThrow()` invocation"
       );
 
       // throws useful error when where has defined non-unique fields
@@ -472,7 +472,7 @@ describe("queries", () => {
           where: { name: firstUser.name },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUniqueOrThrow()` invocation"
+        "Invalid `testClient.user.findUniqueOrThrow()` invocation"
       );
 
       // throws useful error when where has undefined compound unique index field
@@ -481,7 +481,7 @@ describe("queries", () => {
           where: { name_email: undefined },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUniqueOrThrow()` invocation"
+        "Invalid `testClient.user.findUniqueOrThrow()` invocation"
       );
 
       // throws useful error when where has undefined unique field and defined non-unique field
@@ -490,7 +490,7 @@ describe("queries", () => {
           where: { id: undefined, name: firstUser.name },
         })
       ).rejects.toThrowError(
-        "Invalid `prisma.user.findUniqueOrThrow()` invocation"
+        "Invalid `testClient.user.findUniqueOrThrow()` invocation"
       );
     });
 

--- a/test/unit/aggregate.test.ts
+++ b/test/unit/aggregate.test.ts
@@ -14,7 +14,7 @@ describe("aggregate", () => {
     });
 
     // args have not been modified
-    expect(client.user.aggregate).toHaveBeenCalledWith({
+    expect(extendedClient.user.aggregate.query).toHaveBeenCalledWith({
       where: { email: { contains: "test" } },
       _sum: { id: true },
     });
@@ -33,7 +33,7 @@ describe("aggregate", () => {
     await extendedClient.user.aggregate({});
 
     // args have been modified
-    expect(client.user.aggregate).toHaveBeenCalledWith({ where: { deleted: false } });
+    expect(extendedClient.user.aggregate.query).toHaveBeenCalledWith({ where: { deleted: false } });
   });
 
   it("excludes deleted record from aggregate with where", async () => {
@@ -51,7 +51,7 @@ describe("aggregate", () => {
     });
 
     // args have been modified
-    expect(client.user.aggregate).toHaveBeenCalledWith({
+    expect(extendedClient.user.aggregate.query).toHaveBeenCalledWith({
       where: { email: { contains: "test" }, deleted: false },
     });
   });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -27,7 +27,7 @@ describe("config", () => {
       },
     });
 
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         author: { delete: true },
@@ -72,7 +72,7 @@ describe("config", () => {
       },
     });
 
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {
@@ -151,7 +151,7 @@ describe("config", () => {
       },
     });
 
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {
@@ -202,7 +202,7 @@ describe("config", () => {
       },
     });
 
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {

--- a/test/unit/count.test.ts
+++ b/test/unit/count.test.ts
@@ -11,7 +11,7 @@ describe("count", () => {
     await extendedClient.user.count({});
 
     // params have not been modified
-    expect(client.user.count).toHaveBeenCalledWith({});
+    expect(extendedClient.user.count.query).toHaveBeenCalledWith({});
   });
 
   it("excludes deleted records from count", async () => {
@@ -25,7 +25,7 @@ describe("count", () => {
     await extendedClient.user.count(undefined);
 
     // params have been modified
-    expect(client.user.count).toHaveBeenCalledWith({ where: { deleted: false } });
+    expect(extendedClient.user.count.query).toHaveBeenCalledWith({ where: { deleted: false } });
   });
 
   it("excludes deleted records from count with empty args", async () => {
@@ -39,7 +39,7 @@ describe("count", () => {
     await extendedClient.user.count({});
 
     // params have been modified
-    expect(client.user.count).toHaveBeenCalledWith({
+    expect(extendedClient.user.count.query).toHaveBeenCalledWith({
       where: { deleted: false },
     });
   });
@@ -57,7 +57,7 @@ describe("count", () => {
     });
 
     // params have been modified
-    expect(client.user.count).toHaveBeenCalledWith({
+    expect(extendedClient.user.count.query).toHaveBeenCalledWith({
       where: { email: { contains: "test" }, deleted: false },
     });
   });

--- a/test/unit/delete.test.ts
+++ b/test/unit/delete.test.ts
@@ -11,7 +11,7 @@ describe("delete", () => {
     await extendedClient.user.delete({ where: { id: 1 } });
 
     // params have not been modified
-    expect(client.user.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(extendedClient.user.delete.query).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 
   it("does not change nested delete action if model is not in the list", async () => {
@@ -30,7 +30,7 @@ describe("delete", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {
@@ -65,7 +65,7 @@ describe("delete", () => {
     await extendedClient.user.delete(undefined);
 
     // params have not been modified
-    expect(client.user.delete).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.delete.query).toHaveBeenCalledWith(undefined);
     expect(client.user.update).not.toHaveBeenCalled();
   });
 
@@ -79,7 +79,7 @@ describe("delete", () => {
     await extendedClient.user.delete({});
 
     // params have not been modified
-    expect(client.user.delete).toHaveBeenCalledWith({});
+    expect(extendedClient.user.delete.query).toHaveBeenCalledWith({});
     expect(client.user.update).not.toHaveBeenCalled();
   });
 
@@ -116,7 +116,7 @@ describe("delete", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         profile: { delete: false },
@@ -140,7 +140,7 @@ describe("delete", () => {
     });
 
     // params are modified correctly
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         profile: { update: { deleted: true } },
@@ -166,7 +166,7 @@ describe("delete", () => {
     });
 
     // params are modified correctly
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {
@@ -197,7 +197,7 @@ describe("delete", () => {
     });
 
     // params are modified correctly
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {

--- a/test/unit/deleteMany.test.ts
+++ b/test/unit/deleteMany.test.ts
@@ -13,7 +13,7 @@ describe("deleteMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.deleteMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.deleteMany.query).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
@@ -36,7 +36,7 @@ describe("deleteMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {
@@ -138,7 +138,7 @@ describe("deleteMany", () => {
     });
 
     // params are modified correctly
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         posts: {

--- a/test/unit/findFirst.test.ts
+++ b/test/unit/findFirst.test.ts
@@ -13,7 +13,7 @@ describe("findFirst", () => {
     });
 
     // params have not been modified
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
@@ -24,7 +24,7 @@ describe("findFirst", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.findFirst.mockImplementation((() =>
+    extendedClient.user.findFirst.query.mockImplementation((() =>
       Promise.resolve({
         id: 1,
         deleted: true,
@@ -50,7 +50,7 @@ describe("findFirst", () => {
     });
 
     // params have been modified
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: {
         id: 1,
         deleted: false,
@@ -67,7 +67,7 @@ describe("findFirst", () => {
     await extendedClient.user.findFirst(undefined);
 
     // params have been modified
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
       },
@@ -83,7 +83,7 @@ describe("findFirst", () => {
     await extendedClient.user.findFirst({});
 
     // params have been modified
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
       },
@@ -103,7 +103,7 @@ describe("findFirst", () => {
     });
 
     // params have not been modified
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: {
         id: 1,
         deleted: true,

--- a/test/unit/findFirstOrThrow.test.ts
+++ b/test/unit/findFirstOrThrow.test.ts
@@ -13,7 +13,7 @@ describe("findFirstOrThrow", () => {
     });
 
     // params have not been modified
-    expect(client.user.findFirstOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirstOrThrow.query).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
@@ -24,7 +24,7 @@ describe("findFirstOrThrow", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.findFirstOrThrow.mockImplementation((() =>
+    extendedClient.user.findFirstOrThrow.query.mockImplementation((() =>
       Promise.resolve({ id: 1, deleted: true })) as any);
 
     const result = await extendedClient.user.findFirstOrThrow({
@@ -47,7 +47,7 @@ describe("findFirstOrThrow", () => {
     });
 
     // params have been modified
-    expect(client.user.findFirstOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirstOrThrow.query).toHaveBeenCalledWith({
       where: {
         id: 1,
         deleted: false,
@@ -64,7 +64,7 @@ describe("findFirstOrThrow", () => {
     await extendedClient.user.findFirstOrThrow(undefined);
 
     // params have been modified
-    expect(client.user.findFirstOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirstOrThrow.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
       },
@@ -80,7 +80,7 @@ describe("findFirstOrThrow", () => {
     await extendedClient.user.findFirstOrThrow({});
 
     // params have been modified
-    expect(client.user.findFirstOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirstOrThrow.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
       },
@@ -100,7 +100,7 @@ describe("findFirstOrThrow", () => {
     });
 
     // params have not been modified
-    expect(client.user.findFirstOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirstOrThrow.query).toHaveBeenCalledWith({
       where: { id: 1, deleted: true },
     });
   });

--- a/test/unit/findMany.test.ts
+++ b/test/unit/findMany.test.ts
@@ -13,7 +13,7 @@ describe("findMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
@@ -24,7 +24,7 @@ describe("findMany", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.findMany.mockImplementation((() =>
+    extendedClient.user.findMany.query.mockImplementation((() =>
       Promise.resolve([{ id: 1, deleted: true }])) as any);
 
     const result = await extendedClient.user.findMany({
@@ -47,7 +47,7 @@ describe("findMany", () => {
     });
 
     // params have been modified
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       where: {
         id: 1,
         deleted: false,
@@ -66,7 +66,7 @@ describe("findMany", () => {
     await extendedClient.user.findMany(undefined);
 
     // params have been modified
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
       },
@@ -84,7 +84,7 @@ describe("findMany", () => {
     await extendedClient.user.findMany({});
 
     // params have been modified
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
       },
@@ -104,7 +104,7 @@ describe("findMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       where: {
         id: 1,
         deleted: true,

--- a/test/unit/findUnique.test.ts
+++ b/test/unit/findUnique.test.ts
@@ -13,7 +13,7 @@ describe("findUnique", () => {
     });
 
     // params have not been modified
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
@@ -55,7 +55,7 @@ describe("findUnique", () => {
         deleted: false,
       },
     });
-    expect(client.user.findUnique).not.toHaveBeenCalled();
+    expect(extendedClient.user.findUnique.query).not.toHaveBeenCalled();
   });
 
   it("throws when trying to pass a findUnique where with a compound unique index field", async () => {
@@ -104,7 +104,7 @@ describe("findUnique", () => {
     });
 
     // params have not been modified
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: {
         name_email: {
           name: "test",
@@ -127,7 +127,7 @@ describe("findUnique", () => {
     await extendedClient.user.findUnique(undefined);
 
     // params have not been modified
-    expect(client.user.findUnique).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith(undefined);
     expect(client.user.findFirst).not.toHaveBeenCalled();
   });
 
@@ -141,32 +141,32 @@ describe("findUnique", () => {
 
     // @ts-expect-error testing if user doesn't pass where accidentally
     await extendedClient.user.findUnique({});
-    expect(client.user.findUnique).toHaveBeenCalledWith({});
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({});
     client.user.findUnique.mockClear();
 
     // expect empty where not to modify params
     // @ts-expect-error testing if user passes where without unique field
     await extendedClient.user.findUnique({ where: {} });
-    expect(client.user.findUnique).toHaveBeenCalledWith({ where: {} });
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({ where: {} });
     client.user.findUnique.mockClear();
 
     // expect where with undefined id field not to modify params
     await extendedClient.user.findUnique({ where: { id: undefined } });
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: { id: undefined },
     });
     client.user.findUnique.mockClear();
 
     // expect where with undefined unique field not to modify params
     await extendedClient.user.findUnique({ where: { email: undefined } });
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: { email: undefined },
     });
     client.user.findUnique.mockClear();
 
     // expect where with undefined unique index field not to modify params
     await extendedClient.user.findUnique({ where: { name_email: undefined } });
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: { name_email: undefined },
     });
     client.user.findUnique.mockClear();
@@ -174,7 +174,7 @@ describe("findUnique", () => {
     // expect where with defined non-unique field
     // @ts-expect-error intentionally incorrect where
     await extendedClient.user.findUnique({ where: { name: "test" } });
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: { name: "test" },
     });
     client.user.findUnique.mockClear();
@@ -183,7 +183,7 @@ describe("findUnique", () => {
     await extendedClient.user.findUnique({
       where: { id: undefined, name: "test" },
     });
-    expect(client.user.findUnique).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
       where: { id: undefined, name: "test" },
     });
   });

--- a/test/unit/findUniqueOrThrow.test.ts
+++ b/test/unit/findUniqueOrThrow.test.ts
@@ -13,7 +13,7 @@ describe("findUniqueOrThrow", () => {
     });
 
     // params have not been modified
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
@@ -55,7 +55,7 @@ describe("findUniqueOrThrow", () => {
         deleted: false,
       },
     });
-    expect(client.user.findUniqueOrThrow).not.toHaveBeenCalled();
+    expect(extendedClient.user.findUniqueOrThrow.query).not.toHaveBeenCalled();
   });
 
   it("does not modify findUniqueOrThrow to be a findFirstOrThrow when no args passed", async () => {
@@ -70,7 +70,7 @@ describe("findUniqueOrThrow", () => {
     await extendedClient.user.findUniqueOrThrow(undefined);
 
     // params have not been modified
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith(undefined);
   });
 
   it("does not modify findUniqueOrThrow to be a findFirst when invalid where passed", async () => {
@@ -83,18 +83,18 @@ describe("findUniqueOrThrow", () => {
 
     // @ts-expect-error testing if user doesn't pass where accidentally
     await extendedClient.user.findUniqueOrThrow({});
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({});
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({});
     client.user.findUniqueOrThrow.mockClear();
 
     // expect empty where not to modify params
     // @ts-expect-error testing if user passes where without unique field
     await extendedClient.user.findUniqueOrThrow({ where: {} });
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({ where: {} });
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({ where: {} });
     client.user.findUniqueOrThrow.mockClear();
 
     // expect where with undefined id field not to modify params
     await extendedClient.user.findUniqueOrThrow({ where: { id: undefined } });
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
       where: { id: undefined },
     });
     client.user.findUniqueOrThrow.mockClear();
@@ -103,7 +103,7 @@ describe("findUniqueOrThrow", () => {
     await extendedClient.user.findUniqueOrThrow({
       where: { email: undefined },
     });
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
       where: { email: undefined },
     });
     client.user.findUniqueOrThrow.mockClear();
@@ -112,7 +112,7 @@ describe("findUniqueOrThrow", () => {
     await extendedClient.user.findUniqueOrThrow({
       where: { name_email: undefined },
     });
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
       where: { name_email: undefined },
     });
     client.user.findUniqueOrThrow.mockClear();
@@ -120,7 +120,7 @@ describe("findUniqueOrThrow", () => {
     // expect where with defined non-unique field
     // @ts-expect-error intentionally incorrect where
     await extendedClient.user.findUniqueOrThrow({ where: { name: "test" } });
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
       where: { name: "test" },
     });
     client.user.findUniqueOrThrow.mockClear();
@@ -129,7 +129,7 @@ describe("findUniqueOrThrow", () => {
     await extendedClient.user.findUniqueOrThrow({
       where: { id: undefined, name: "test" },
     });
-    expect(client.user.findUniqueOrThrow).toHaveBeenCalledWith({
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
       where: { id: undefined, name: "test" },
     });
   });

--- a/test/unit/groupBy.test.ts
+++ b/test/unit/groupBy.test.ts
@@ -16,7 +16,7 @@ describe("groupBy", () => {
     });
 
     // params have not been modified
-    expect(client.user.groupBy).toHaveBeenCalledWith({
+    expect(extendedClient.user.groupBy.query).toHaveBeenCalledWith({
       where: { id: 1 },
       by: ["id"],
       orderBy: {},
@@ -29,7 +29,7 @@ describe("groupBy", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.groupBy.mockImplementation(
+    extendedClient.user.groupBy.query.mockImplementation(
       () => Promise.resolve([{ id: 1, deleted: true }]) as any
     );
 
@@ -57,7 +57,7 @@ describe("groupBy", () => {
     });
 
     // params have been modified
-    expect(client.user.groupBy).toHaveBeenCalledWith({
+    expect(extendedClient.user.groupBy.query).toHaveBeenCalledWith({
       by: ["id"],
       orderBy: {},
       where: {
@@ -82,7 +82,7 @@ describe("groupBy", () => {
     });
 
     // params have not been modified
-    expect(client.user.groupBy).toHaveBeenCalledWith({
+    expect(extendedClient.user.groupBy.query).toHaveBeenCalledWith({
       by: ["id"],
       orderBy: {},
       where: {

--- a/test/unit/include.test.ts
+++ b/test/unit/include.test.ts
@@ -17,7 +17,7 @@ describe("include", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       include: { comments: true },
@@ -41,7 +41,7 @@ describe("include", () => {
     });
 
     // params have been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       include: {
@@ -75,7 +75,7 @@ describe("include", () => {
     });
 
     // params have been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       include: {
@@ -97,7 +97,7 @@ describe("include", () => {
       })
     );
 
-    client.post.update.mockImplementation(
+    extendedClient.post.update.query.mockImplementation(
       () => Promise.resolve({ author: { deleted: true } }) as any
     );
 
@@ -109,7 +109,7 @@ describe("include", () => {
       },
     });
 
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { content: "foo" },
       include: {
@@ -127,7 +127,7 @@ describe("include", () => {
       })
     );
 
-    client.post.update.mockImplementation(
+    extendedClient.post.update.query.mockImplementation(
       () => Promise.resolve({ author: { deleted: false } }) as any
     );
     const result = await extendedClient.post.update({
@@ -138,7 +138,7 @@ describe("include", () => {
       },
     });
 
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { content: "foo" },
       include: {
@@ -156,7 +156,7 @@ describe("include", () => {
       })
     );
 
-    client.post.update.mockImplementation(
+    extendedClient.post.update.query.mockImplementation(
       () => Promise.resolve({ author: { deleted: true, comments: [] } }) as any
     );
 
@@ -172,7 +172,7 @@ describe("include", () => {
       },
     });
 
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { content: "foo" },
       include: {
@@ -194,7 +194,7 @@ describe("include", () => {
       })
     );
 
-    client.post.update.mockImplementation(
+    extendedClient.post.update.query.mockImplementation(
       () =>
         Promise.resolve({
           author: {
@@ -232,7 +232,7 @@ describe("include", () => {
       })
     );
 
-    client.user.findFirst.mockImplementation(
+    extendedClient.user.findFirst.query.mockImplementation(
       () =>
         Promise.resolve({
           posts: [
@@ -260,7 +260,7 @@ describe("include", () => {
       },
     });
 
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: { id: 1 },
       include: {
         posts: {
@@ -290,7 +290,7 @@ describe("include", () => {
       })
     );
 
-    client.user.findFirst.mockImplementation(
+    extendedClient.user.findFirst.query.mockImplementation(
       () =>
         Promise.resolve({
           posts: [
@@ -312,7 +312,7 @@ describe("include", () => {
       },
     });
 
-    expect(client.user.findFirst).toHaveBeenCalledWith({
+    expect(extendedClient.user.findFirst.query).toHaveBeenCalledWith({
       where: { id: 1, deleted: false },
       include: {
         posts: {
@@ -339,7 +339,7 @@ describe("include", () => {
       })
     );
 
-    client.user.update.mockImplementation(
+    extendedClient.user.update.query.mockImplementation(
       () =>
         Promise.resolve({
           comments: [{ deleted: true }, { deleted: true }],
@@ -358,7 +358,7 @@ describe("include", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       include: {

--- a/test/unit/select.test.ts
+++ b/test/unit/select.test.ts
@@ -17,7 +17,7 @@ describe("select", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       select: { comments: true },
@@ -41,7 +41,7 @@ describe("select", () => {
     });
 
     // params have been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       select: {
@@ -75,7 +75,7 @@ describe("select", () => {
     });
 
     // params have been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       select: {
@@ -108,7 +108,7 @@ describe("select", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       include: {
@@ -141,7 +141,7 @@ describe("select", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
       select: {

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -14,7 +14,7 @@ describe("update", () => {
     });
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: { email: "test@test.com" },
     });
@@ -26,7 +26,7 @@ describe("update", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.update.mockImplementation(
+    extendedClient.user.update.query.mockImplementation(
       () => Promise.resolve({ id: 1, name: "John" }) as any
     );
     const result = await extendedClient.user.update({
@@ -86,7 +86,7 @@ describe("update", () => {
     });
 
     // params have not been modified
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         author: {
@@ -123,7 +123,7 @@ describe("update", () => {
     });
 
     // params have not been modified
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         comments: {
@@ -150,7 +150,7 @@ describe("update", () => {
     await extendedClient.user.update(undefined);
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith(undefined);
   });
 
   it("does not modify update when no where is passed", async () => {
@@ -163,6 +163,6 @@ describe("update", () => {
     await extendedClient.user.update({});
 
     // params have not been modified
-    expect(client.user.update).toHaveBeenCalledWith({});
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({});
   });
 });

--- a/test/unit/updateMany.test.ts
+++ b/test/unit/updateMany.test.ts
@@ -14,7 +14,7 @@ describe("updateMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.updateMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith({
       where: { id: { in: [1, 2] } },
       data: { email: "test@test.com" },
     });
@@ -26,7 +26,7 @@ describe("updateMany", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.updateMany.mockImplementation(
+    extendedClient.user.updateMany.query.mockImplementation(
       () => Promise.resolve({ count: 1 }) as any
     );
 
@@ -48,7 +48,7 @@ describe("updateMany", () => {
     await extendedClient.user.updateMany(undefined);
 
     // params have not been modified
-    expect(client.user.updateMany).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith(undefined);
   });
 
   it("excludes deleted records from root updateMany action", async () => {
@@ -65,7 +65,7 @@ describe("updateMany", () => {
     });
 
     // params have been modified
-    expect(client.user.updateMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith({
       data: { email: "test@test.com" },
       where: {
         id: 1,
@@ -87,7 +87,7 @@ describe("updateMany", () => {
     });
 
     // params have been modified
-    expect(client.user.updateMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith({
       data: { name: "John" },
       where: {
         deleted: false,
@@ -124,7 +124,7 @@ describe("updateMany", () => {
     });
 
     // params have been modified
-    expect(client.user.update).toHaveBeenCalledWith({
+    expect(extendedClient.user.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         comments: {
@@ -162,7 +162,7 @@ describe("updateMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.updateMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith({
       where: { id: { in: [1, 2] }, deleted: true },
       data: { email: "test@test.com" },
     });
@@ -190,7 +190,7 @@ describe("updateMany", () => {
     });
 
     // params have not been modified
-    expect(client.user.updateMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith({
       where: { id: { in: [1, 2] }, deletedAt: { not: null } },
       data: { email: "test@test.com" },
     });

--- a/test/unit/upsert.test.ts
+++ b/test/unit/upsert.test.ts
@@ -8,7 +8,7 @@ describe("upsert", () => {
       createSoftDeleteExtension({ models: { User: true } })
     );
 
-    client.user.upsert.mockImplementation(
+    extendedClient.user.upsert.query.mockImplementation(
       () =>
         Promise.resolve({ id: 1, name: "John", email: "John@test.com" }) as any
     );
@@ -39,7 +39,7 @@ describe("upsert", () => {
       update: { name: "John" },
     });
 
-    expect(client.user.upsert).toHaveBeenCalledWith({
+    expect(extendedClient.user.upsert.query).toHaveBeenCalledWith({
       where: { id: 1 },
       create: { name: "John", email: "john@test.com" },
       update: { name: "John" },
@@ -67,7 +67,7 @@ describe("upsert", () => {
       },
     });
 
-    expect(client.post.update).toHaveBeenCalledWith({
+    expect(extendedClient.post.update.query).toHaveBeenCalledWith({
       where: { id: 1 },
       data: {
         comments: {

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -22,7 +22,7 @@ describe("where", () => {
     });
 
     // params have not been modified
-    expect(client.user.deleteMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.deleteMany.query).toHaveBeenCalledWith({
       where: {
         email: expect.any(String),
         comments: {
@@ -65,7 +65,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.user.deleteMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.deleteMany.query).toHaveBeenCalledWith({
       where: {
         email: expect.any(String),
         comments: {
@@ -127,7 +127,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.comment.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.comment.findMany.query).toHaveBeenCalledWith({
       where: {
         deleted: false,
         content: expect.any(String),
@@ -197,7 +197,7 @@ describe("where", () => {
     });
 
     // params have been modified
-    expect(client.user.deleteMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.deleteMany.query).toHaveBeenCalledWith({
       where: {
         email: expect.any(String),
         comments: {
@@ -277,7 +277,7 @@ describe("where", () => {
     });
 
     // params have been modified
-    expect(client.user.deleteMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.deleteMany.query).toHaveBeenCalledWith({
       where: {
         email: expect.any(String),
         comments: {
@@ -362,7 +362,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.user.deleteMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.deleteMany.query).toHaveBeenCalledWith({
       where: {
         email: expect.any(String),
         comments: {
@@ -430,7 +430,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       include: {
         posts: {
           where: {
@@ -470,7 +470,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       select: {
         posts: {
           where: {
@@ -514,7 +514,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       include: {
         comments: {
           where: {
@@ -563,7 +563,7 @@ describe("where", () => {
       },
     });
 
-    expect(client.user.findMany).toHaveBeenCalledWith({
+    expect(extendedClient.user.findMany.query).toHaveBeenCalledWith({
       select: {
         comments: {
           where: {


### PR DESCRIPTION
Closes #22

The changes done to fix RLS in #19 had an unfortunate side-effect of breaking the Fluent API. Additionally the issues found in #19 seem to be related to transactions, which are still not working correctly.

Revert the changes for #19 while still keeping the improvements to the unit test setup.

BREAKING CHANGE: the previous client is no longer always used.

Users who use RLS extensions might encounter issues as the strategy of always using the previous client is being reverted.