### PR TITLE
Using getDMMF

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,19 @@
   "author": "Olivier Wilkinson",
   "license": "Apache-2.0",
   "dependencies": {
+    "c12": "3.1.0",
+    "deepmerge-ts": "7.1.5",
     "prisma-extension-nested-operations": "^1.0.1"
   },
   "peerDependencies": {
-    "@prisma/client": "*"
+    "@prisma/client": "*",
+    "@prisma/internals": "*",
+    "@prisma/dmmf": "*"
   },
   "devDependencies": {
-    "@prisma/client": "^5.4.2",
+    "@prisma/client": "^7.4.2",
+    "@prisma/dmmf": "^7.4.2",
+    "@prisma/internals": "^7.4.2",
     "@types/faker": "^5.5.9",
     "@types/jest": "^29.2.5",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
@@ -46,11 +52,11 @@
     "jest": "^29.3.1",
     "kcd-scripts": "^5.0.0",
     "npm-run-all": "^4.1.5",
-    "prisma": "^5.4.2",
+    "prisma": "^7.4.2",
     "semantic-release": "^17.0.2",
     "ts-jest": "^29.0.3",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
+    "typescript": "^5.4.0"
   },
   "repository": {
     "type": "git",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma",
+  datasource: {
+    url: process.env.DATABASE_URL,
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model User {

--- a/src/lib/createSoftDeleteExtension.ts
+++ b/src/lib/createSoftDeleteExtension.ts
@@ -22,6 +22,7 @@ import {
   createWhereParams,
   createGroupByParams,
   CreateParams,
+  init,
 } from "./helpers/createParams";
 
 import { Config, ModelConfig } from "./types";
@@ -39,6 +40,7 @@ export function createSoftDeleteExtension({
     allowToOneUpdates: false,
     allowCompoundUniqueIndexWhere: false,
   },
+  rootDir,
 }: Config) {
   if (!defaultConfig.field) {
     throw new Error(
@@ -50,6 +52,8 @@ export function createSoftDeleteExtension({
       "prisma-extension-soft-delete: defaultConfig.createValue is required"
     );
   }
+
+  init(rootDir);
 
   const modelConfig: Partial<Record<Prisma.ModelName, ModelConfig>> = {};
 
@@ -109,8 +113,8 @@ export function createSoftDeleteExtension({
     return client.$extends({
       query: {
         $allModels: {
-          // @ts-expect-error - we don't know what the client is
           $allOperations: withNestedOperations({
+            // @ts-expect-error - we don't know what the client is
             async $rootOperation(initialParams) {
               const createParams =
                 createParamsByModel[initialParams.model || ""]?.[

--- a/src/lib/helpers/createParams.ts
+++ b/src/lib/helpers/createParams.ts
@@ -1,29 +1,67 @@
-import { Prisma } from "@prisma/client";
+import fs from "fs";
+import path from "path";
+import { Document } from "@prisma/dmmf";
 import { NestedParams } from "prisma-extension-nested-operations";
 
+import { getDMMF, MultipleSchemas } from "@prisma/internals";
 import { ModelConfig } from "../types";
 import { addDeletedToSelect } from "../utils/nestedReads";
+import { getSchemasPath } from "./getSchemasPath";
 
 const uniqueFieldsByModel: Record<string, string[]> = {};
 const uniqueIndexFieldsByModel: Record<string, string[]> = {};
 
-Prisma.dmmf.datamodel.models.forEach((model) => {
-  // add unique fields derived from indexes
-  const uniqueIndexFields: string[] = [];
-  model.uniqueFields.forEach((field) => {
-    uniqueIndexFields.push(field.join("_"));
-  });
-  uniqueIndexFieldsByModel[model.name] = uniqueIndexFields;
+function DMMFReader(dmmf: Document) {
+  dmmf.datamodel.models.forEach((model) => {
+    // add unique fields derived from indexes
+    const uniqueIndexFields: string[] = [];
+    model.uniqueFields.forEach((field) => {
+      uniqueIndexFields.push(field.join("_"));
+    });
+    uniqueIndexFieldsByModel[model.name] = uniqueIndexFields;
 
-  // add id field and unique fields from @unique decorator
-  const uniqueFields: string[] = [];
-  model.fields.forEach((field) => {
-    if (field.isId || field.isUnique) {
-      uniqueFields.push(field.name);
-    }
+    // add id field and unique fields from @unique decorator
+    const uniqueFields: string[] = [];
+    model.fields.forEach((field) => {
+      if (field.isId || field.isUnique) {
+        uniqueFields.push(field.name);
+      }
+    });
+    uniqueFieldsByModel[model.name] = uniqueFields;
   });
-  uniqueFieldsByModel[model.name] = uniqueFields;
-});
+}
+
+export async function init(rootDir: string) {
+  const schemasPath = await getSchemasPath(rootDir);
+
+  if (fs.statSync(schemasPath).isFile()) {
+    const fileContent = fs.readFileSync(schemasPath, { encoding: "utf-8" });
+    const dmmf = await getDMMF({
+      datamodel: fileContent,
+    });
+    DMMFReader(dmmf);
+    return;
+  }
+
+  const files = fs.readdirSync(schemasPath, {
+    encoding: "utf-8",
+    recursive: true,
+  });
+
+  const schemasContent: MultipleSchemas = [];
+  for (const file of files) {
+    const filePath = path.join(schemasPath, file);
+    if (filePath.endsWith(".prisma") && fs.statSync(filePath).isFile()) {
+      const fileContent = fs.readFileSync(filePath, { encoding: "utf-8" });
+      schemasContent.push([filePath, fileContent]);
+    }
+  }
+
+  const dmmf = await getDMMF({
+    datamodel: schemasContent,
+  });
+  DMMFReader(dmmf);
+}
 
 export type Params = Omit<NestedParams<any>, "operation"> & {
   operation: string;
@@ -154,10 +192,7 @@ export const createUpsertParams: CreateParams = (_, params) => {
   return { params };
 };
 
-function validateFindUniqueParams(
-  params: Params,
-  config: ModelConfig
-): void {
+function validateFindUniqueParams(params: Params, config: ModelConfig): void {
   const uniqueIndexFields = uniqueIndexFieldsByModel[params.model || ""] || [];
   const uniqueIndexField = Object.keys(params.args?.where || {}).find((key) =>
     uniqueIndexFields.includes(key)
@@ -215,7 +250,8 @@ export const createFindUniqueParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]: params.args?.where?.[config.field] || config.createValue(false),
+          [config.field]:
+            params.args?.where?.[config.field] || config.createValue(false),
         },
       },
     },
@@ -238,7 +274,8 @@ export const createFindUniqueOrThrowParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]: params.args?.where?.[config.field] || config.createValue(false),
+          [config.field]:
+            params.args?.where?.[config.field] || config.createValue(false),
         },
       },
     },

--- a/src/lib/helpers/getSchemasPath.ts
+++ b/src/lib/helpers/getSchemasPath.ts
@@ -1,0 +1,60 @@
+import path from 'node:path'
+import fs from "fs";
+
+// eslint-disable-next-line import/no-unresolved
+import { loadConfig as loadConfigWithC12 } from "c12";
+import { deepmerge } from "deepmerge-ts";
+
+export const SUPPORTED_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs', '.mts', '.cts'] as const satisfies string[]
+
+export async function getSchemasPath(configRoot: string) {
+    const {
+      config,
+      configFile: _resolvedPath,
+    } = await loadConfigWithC12({
+      cwd: configRoot,
+      // configuration base name
+      name: 'prisma',
+      // do not load .env files
+      dotenv: false,
+      // do not load RC config
+      rcFile: false,
+      // do not extend remote config files
+      giget: false,
+      // do not extend the default config
+      extend: false,
+      // do not load from nearest package.json
+      packageJson: false,
+
+      // @ts-expect-error: this is a type-error in `c12` itself
+      merger: deepmerge,
+
+      jitiOptions: {
+        interopDefault: true,
+        moduleCache: false,
+        extensions: SUPPORTED_EXTENSIONS,
+      },
+    })
+
+    // Note: c12 apparently doesn't normalize paths on Windows, causing issues with Windows tests.
+    const resolvedPath = _resolvedPath ? path.normalize(_resolvedPath) : undefined
+
+  if (config.schema === undefined || resolvedPath === undefined) {
+    const defPath1 = path.join(configRoot, "prisma/schema.prisma");
+    if (fs.existsSync(defPath1)) {
+      return defPath1;
+    }
+
+    const defPath2 = path.join(configRoot, "schema.prisma");
+    if (fs.existsSync(defPath2)) {
+      return defPath2;
+    }
+
+    throw new Error("Didn't find prisma schemas");
+  }
+
+  const splitPath = resolvedPath.split("/");
+  splitPath.pop();
+
+  return path.join(splitPath.join("/"), config.schema);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,4 +10,5 @@ export type ModelConfig = {
 export type Config = {
   models: Partial<Record<Prisma.ModelName, ModelConfig | boolean>>;
   defaultConfig?: ModelConfig;
+  rootDir: string;
 };

--- a/test/e2e/deletedAt.test.ts
+++ b/test/e2e/deletedAt.test.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, Profile, User } from "@prisma/client";
 import faker from "faker";
 
+import { rootDir } from "../unit/utils/mockClient";
 import { createSoftDeleteExtension } from "../../src";
 import client from "./client";
 
@@ -12,18 +13,17 @@ describe("deletedAt", () => {
   beforeAll(async () => {
     testClient = new PrismaClient();
     testClient = testClient.$extends(
-      createSoftDeleteExtension(
-        {
-          models: {
-            User: {
-              field: "deletedAt",
-              createValue: (deleted) => {
-                return deleted ? new Date() : null;
-              },
+      createSoftDeleteExtension({
+        models: {
+          User: {
+            field: "deletedAt",
+            createValue: (deleted) => {
+              return deleted ? new Date() : null;
             },
           },
         },
-      )
+        rootDir,
+      })
     );
 
     profile = await client.profile.create({

--- a/test/e2e/fluent.test.ts
+++ b/test/e2e/fluent.test.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, Profile, User } from "@prisma/client";
 import faker from "faker";
 
+import { rootDir } from "../unit/utils/mockClient";
 import { createSoftDeleteExtension } from "../../src";
 import client from "./client";
 
@@ -12,7 +13,10 @@ describe("fluent", () => {
   beforeAll(async () => {
     testClient = new PrismaClient();
     testClient = testClient.$extends(
-      createSoftDeleteExtension({ models: { Comment: true, Profile: true } })
+      createSoftDeleteExtension({
+        models: { Comment: true, Profile: true },
+        rootDir,
+      })
     );
 
     profile = await client.profile.create({

--- a/test/e2e/nestedReads.test.ts
+++ b/test/e2e/nestedReads.test.ts
@@ -2,6 +2,7 @@ import { PrismaClient, User } from "@prisma/client";
 import faker from "faker";
 
 import { createSoftDeleteExtension } from "../../src";
+import { rootDir } from "../unit/utils/mockClient";
 import client from "./client";
 
 describe("nested reads", () => {
@@ -12,7 +13,7 @@ describe("nested reads", () => {
     testClient = new PrismaClient();
     testClient = testClient.$extends(
       createSoftDeleteExtension(
-        { models: { Comment: true, Profile: true } },
+        { models: { Comment: true, Profile: true }, rootDir },
         // @ts-expect-error - we don't know what the client is
         { client: testClient }
       )

--- a/test/e2e/queries.test.ts
+++ b/test/e2e/queries.test.ts
@@ -1,6 +1,7 @@
 import { Comment, PrismaClient, Profile, User, Prisma } from "@prisma/client";
 import faker from "faker";
 
+import { rootDir } from "../unit/utils/mockClient";
 import { createSoftDeleteExtension } from "../../src";
 import client from "./client";
 
@@ -15,7 +16,7 @@ describe("queries", () => {
   beforeAll(async () => {
     testClient = new PrismaClient();
     testClient = testClient.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     profile = await client.profile.create({
@@ -362,41 +363,42 @@ describe("queries", () => {
       expect(notFoundUser).toBeNull();
     });
 
-    it.failing("does not break interactive transaction", async() => {
+    it.failing("does not break interactive transaction", async () => {
       // eslint-disable-next-line prefer-const
       let localClient = testClient;
 
       // uncomment to make this test succeed
       // localClient = new PrismaClient();
 
-      await localClient.$transaction(async (transactionClient: any) => {
+      await localClient.$transaction(
+        async (transactionClient: any) => {
+          // read within transaction
+          const userRead1 = await transactionClient.user.findUnique({
+            where: { id: firstUser.id },
+          });
+          expect(userRead1.name).toBe("Jack");
 
-        // read within transaction
-        const userRead1 = await transactionClient.user.findUnique({
-          where: { id: firstUser.id },
-        });
-        expect(userRead1.name).toBe('Jack');
+          // modify outside of transaction
+          await localClient.user.update({
+            where: { id: firstUser.id },
+            data: {
+              name: "Jill",
+            },
+          });
 
-        // modify outside of transaction
-        await localClient.user.update({
-          where: { id: firstUser.id },
-          data: {
-            name: 'Jill',
-          },
-        });
+          // read again within transaction
+          const userRead2 = await transactionClient.user.findUnique({
+            where: { id: firstUser.id },
+          });
 
-        // read again within transaction
-        const userRead2 = await transactionClient.user.findUnique({
-          where: { id: firstUser.id },
-        });
-
-        // read is repeatable
-        expect(userRead2.name).toBe('Jack');
-  
-      }, { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead });
+          // read is repeatable
+          expect(userRead2.name).toBe("Jack");
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead }
+      );
     });
 
-    it.failing("does not break sequential transaction", async() => {
+    it.failing("does not break sequential transaction", async () => {
       // eslint-disable-next-line prefer-const
       let localClient: PrismaClient = testClient;
 
@@ -406,27 +408,24 @@ describe("queries", () => {
       const [[userRead1, _, userRead2]] = await Promise.all([
         localClient.$transaction(
           [
-
             // read within transaction (userRead1)
             localClient.user.findUniqueOrThrow({
               where: { id: firstUser.id },
             }),
-            
+
             // sleep for 2 seconds to allow concurrent modification
             localClient.$executeRaw`SELECT pg_sleep(1)`,
 
-            
             // read again within transaction (userRead2)
             localClient.user.findUniqueOrThrow({
               where: { id: firstUser.id },
-            })
+            }),
           ],
           {
             isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead,
           }
         ),
         localClient.$transaction([
-
           // sleep for 1 second to allow first read to happen in other transaction
           localClient.$executeRaw`SELECT pg_sleep(1)`,
 
@@ -434,17 +433,17 @@ describe("queries", () => {
           localClient.user.update({
             where: { id: firstUser.id },
             data: {
-              name: 'Jill',
+              name: "Jill",
             },
-          })
+          }),
         ]),
       ]);
 
       // read is repeatable
-      expect(userRead1.name).toBe('Jack');
-      expect(userRead2.name).toBe('Jack');
+      expect(userRead1.name).toBe("Jack");
+      expect(userRead2.name).toBe("Jack");
     });
-    
+
     it("throws a useful error when invalid where is passed", async () => {
       // throws useful error when no where is passed
       await expect(() => testClient.user.findUnique()).rejects.toThrowError(

--- a/test/e2e/where.test.ts
+++ b/test/e2e/where.test.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, Profile, User } from "@prisma/client";
 import faker from "faker";
 
+import { rootDir } from "../unit/utils/mockClient";
 import { createSoftDeleteExtension } from "../../src";
 import client from "./client";
 
@@ -12,7 +13,10 @@ describe("where", () => {
   beforeAll(async () => {
     testClient = new PrismaClient();
     testClient = testClient.$extends(
-      createSoftDeleteExtension({ models: { Comment: true, Profile: true } })
+      createSoftDeleteExtension({
+        models: { Comment: true, Profile: true },
+        rootDir,
+      })
     );
 
     profile = await client.profile.create({

--- a/test/unit/aggregate.test.ts
+++ b/test/unit/aggregate.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("aggregate", () => {
   it("does not change aggregate action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.aggregate({
@@ -27,13 +27,16 @@ describe("aggregate", () => {
         models: {
           User: true,
         },
+        rootDir,
       })
     );
 
     await extendedClient.user.aggregate({});
 
     // args have been modified
-    expect(extendedClient.user.aggregate.query).toHaveBeenCalledWith({ where: { deleted: false } });
+    expect(extendedClient.user.aggregate.query).toHaveBeenCalledWith({
+      where: { deleted: false },
+    });
   });
 
   it("excludes deleted record from aggregate with where", async () => {
@@ -43,6 +46,7 @@ describe("aggregate", () => {
         models: {
           User: true,
         },
+        rootDir,
       })
     );
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,7 +1,7 @@
 import faker from "faker";
 
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("config", () => {
   it('does not soft delete models where config is passed as "false"', async () => {
@@ -11,6 +11,7 @@ describe("config", () => {
         models: {
           User: false,
         },
+        rootDir,
       })
     );
 
@@ -54,6 +55,7 @@ describe("config", () => {
           field: "deletedAt",
           createValue: () => deletedAt,
         },
+        rootDir,
       })
     );
 
@@ -135,6 +137,7 @@ describe("config", () => {
           },
           Comment: true,
         },
+        rootDir,
       })
     );
 
@@ -186,6 +189,7 @@ describe("config", () => {
             return null;
           },
         },
+        rootDir,
       })
     );
 

--- a/test/unit/count.test.ts
+++ b/test/unit/count.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("count", () => {
   it("does not change count action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.count({});
@@ -19,13 +19,16 @@ describe("count", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
     await extendedClient.user.count(undefined);
 
     // params have been modified
-    expect(extendedClient.user.count.query).toHaveBeenCalledWith({ where: { deleted: false } });
+    expect(extendedClient.user.count.query).toHaveBeenCalledWith({
+      where: { deleted: false },
+    });
   });
 
   it("excludes deleted records from count with empty args", async () => {
@@ -33,6 +36,7 @@ describe("count", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -49,6 +53,7 @@ describe("count", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 

--- a/test/unit/delete.test.ts
+++ b/test/unit/delete.test.ts
@@ -1,23 +1,25 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("delete", () => {
   it("does not change delete action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.delete({ where: { id: 1 } });
 
     // params have not been modified
-    expect(extendedClient.user.delete.query).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(extendedClient.user.delete.query).toHaveBeenCalledWith({
+      where: { id: 1 },
+    });
   });
 
   it("does not change nested delete action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.update({
@@ -43,7 +45,7 @@ describe("delete", () => {
   it("does not modify delete results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     const queryResult = { id: 1, deleted: true };
@@ -57,7 +59,7 @@ describe("delete", () => {
   it("does not modify delete with no args", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     client.user.delete.mockImplementation((() => Promise.resolve({})) as any);
@@ -72,7 +74,7 @@ describe("delete", () => {
   it("does not modify delete with no where", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     // @ts-expect-error - where is required
@@ -88,6 +90,7 @@ describe("delete", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -105,6 +108,7 @@ describe("delete", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Profile: true },
+        rootDir,
       })
     );
 
@@ -129,6 +133,7 @@ describe("delete", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Profile: true },
+        rootDir,
       })
     );
 
@@ -153,6 +158,7 @@ describe("delete", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Post: true },
+        rootDir,
       })
     );
 
@@ -184,6 +190,7 @@ describe("delete", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Post: true },
+        rootDir,
       })
     );
 

--- a/test/unit/deleteMany.test.ts
+++ b/test/unit/deleteMany.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("deleteMany", () => {
   it("does not change deleteMany action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.deleteMany({
@@ -21,7 +21,7 @@ describe("deleteMany", () => {
   it("does not change nested deleteMany action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.update({
@@ -51,7 +51,7 @@ describe("deleteMany", () => {
   it("does not modify deleteMany results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     const queryResult = { count: 1 };
@@ -70,6 +70,7 @@ describe("deleteMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -89,6 +90,7 @@ describe("deleteMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -106,6 +108,7 @@ describe("deleteMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -123,6 +126,7 @@ describe("deleteMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Post: true },
+        rootDir,
       })
     );
 

--- a/test/unit/findFirst.test.ts
+++ b/test/unit/findFirst.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("findFirst", () => {
   it("does not change findFirst params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.findFirst({
@@ -21,7 +21,7 @@ describe("findFirst", () => {
   it("does not modify findFirst results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.findFirst.query.mockImplementation((() =>
@@ -42,6 +42,7 @@ describe("findFirst", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -61,7 +62,7 @@ describe("findFirst", () => {
   it("excludes deleted records from findFirst with no args", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     await extendedClient.user.findFirst(undefined);
@@ -77,7 +78,7 @@ describe("findFirst", () => {
   it("excludes deleted records from findFirst with empty args", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     await extendedClient.user.findFirst({});
@@ -95,6 +96,7 @@ describe("findFirst", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 

--- a/test/unit/findFirstOrThrow.test.ts
+++ b/test/unit/findFirstOrThrow.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("findFirstOrThrow", () => {
   it("does not change findFirstOrThrow params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.findFirstOrThrow({
@@ -21,7 +21,7 @@ describe("findFirstOrThrow", () => {
   it("does not modify findFirstOrThrow results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.findFirstOrThrow.query.mockImplementation((() =>
@@ -39,6 +39,7 @@ describe("findFirstOrThrow", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -58,7 +59,7 @@ describe("findFirstOrThrow", () => {
   it("excludes deleted records from findFirstOrThrow with no args", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     await extendedClient.user.findFirstOrThrow(undefined);
@@ -74,7 +75,7 @@ describe("findFirstOrThrow", () => {
   it("excludes deleted records from findFirstOrThrow with empty args", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     await extendedClient.user.findFirstOrThrow({});
@@ -92,6 +93,7 @@ describe("findFirstOrThrow", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 

--- a/test/unit/findMany.test.ts
+++ b/test/unit/findMany.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("findMany", () => {
   it("does not change findMany params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.findMany({
@@ -21,7 +21,7 @@ describe("findMany", () => {
   it("does not modify findMany results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.findMany.query.mockImplementation((() =>
@@ -39,6 +39,7 @@ describe("findMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -60,6 +61,7 @@ describe("findMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -78,6 +80,7 @@ describe("findMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -96,6 +99,7 @@ describe("findMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 

--- a/test/unit/findUnique.test.ts
+++ b/test/unit/findUnique.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("findUnique", () => {
   it("does not change findUnique params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.findUnique({
@@ -21,7 +21,7 @@ describe("findUnique", () => {
   it("does not modify findUnique results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     const queryResult = { id: 1, deleted: true };
@@ -41,6 +41,7 @@ describe("findUnique", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -63,6 +64,7 @@ describe("findUnique", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -85,6 +87,7 @@ describe("findUnique", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -113,6 +116,7 @@ describe("findUnique", () => {
             allowCompoundUniqueIndexWhere: true,
           },
         },
+        rootDir,
       })
     );
 
@@ -142,6 +146,7 @@ describe("findUnique", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -149,7 +154,9 @@ describe("findUnique", () => {
     await extendedClient.user.findUnique(undefined);
 
     // params have not been modified
-    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith(
+      undefined
+    );
     expect(client.user.findFirst).not.toHaveBeenCalled();
   });
 
@@ -158,6 +165,7 @@ describe("findUnique", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -169,7 +177,9 @@ describe("findUnique", () => {
     // expect empty where not to modify params
     // @ts-expect-error testing if user passes where without unique field
     await extendedClient.user.findUnique({ where: {} });
-    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({ where: {} });
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
+      where: {},
+    });
     client.user.findUnique.mockClear();
 
     // expect where with undefined id field not to modify params

--- a/test/unit/findUniqueOrThrow.test.ts
+++ b/test/unit/findUniqueOrThrow.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("findUniqueOrThrow", () => {
   it("does not change findUniqueOrThrow params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.findUniqueOrThrow({
@@ -21,7 +21,7 @@ describe("findUniqueOrThrow", () => {
   it("does not modify findUniqueOrThrow results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     const queryResult = { id: 1, deleted: true };
@@ -41,6 +41,7 @@ describe("findUniqueOrThrow", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -63,6 +64,7 @@ describe("findUniqueOrThrow", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -85,6 +87,7 @@ describe("findUniqueOrThrow", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -92,7 +95,9 @@ describe("findUniqueOrThrow", () => {
     await extendedClient.user.findUniqueOrThrow(undefined);
 
     // params have not been modified
-    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith(
+      undefined
+    );
   });
 
   it("does not modify findUniqueOrThrow to be a findFirst when invalid where passed", async () => {
@@ -100,18 +105,23 @@ describe("findUniqueOrThrow", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
     // @ts-expect-error testing if user doesn't pass where accidentally
     await extendedClient.user.findUniqueOrThrow({});
-    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({});
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith(
+      {}
+    );
     client.user.findUniqueOrThrow.mockClear();
 
     // expect empty where not to modify params
     // @ts-expect-error testing if user passes where without unique field
     await extendedClient.user.findUniqueOrThrow({ where: {} });
-    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({ where: {} });
+    expect(extendedClient.user.findUniqueOrThrow.query).toHaveBeenCalledWith({
+      where: {},
+    });
     client.user.findUniqueOrThrow.mockClear();
 
     // expect where with undefined id field not to modify params

--- a/test/unit/groupBy.test.ts
+++ b/test/unit/groupBy.test.ts
@@ -1,12 +1,12 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("groupBy", () => {
   //group by must always have by and order by, else we get an error,
   it("does not change groupBy action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.groupBy({
@@ -26,7 +26,7 @@ describe("groupBy", () => {
   it("does not modify groupBy results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.groupBy.query.mockImplementation(
@@ -47,6 +47,7 @@ describe("groupBy", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -72,6 +73,7 @@ describe("groupBy", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 

--- a/test/unit/include.test.ts
+++ b/test/unit/include.test.ts
@@ -1,13 +1,13 @@
 import faker from "faker";
 
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("include", () => {
   it("does not change include params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.update({
@@ -29,6 +29,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -59,6 +60,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -94,6 +96,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -124,6 +127,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -153,6 +157,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -191,6 +196,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -229,6 +235,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -287,6 +294,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -336,6 +344,7 @@ describe("include", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 

--- a/test/unit/select.test.ts
+++ b/test/unit/select.test.ts
@@ -1,13 +1,13 @@
 import faker from "faker";
 
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("select", () => {
   it("does not change select params if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.update({
@@ -29,6 +29,7 @@ describe("select", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -59,6 +60,7 @@ describe("select", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -94,6 +96,7 @@ describe("select", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -125,6 +128,7 @@ describe("select", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("update", () => {
   it("does not change update action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.update({
@@ -23,7 +23,7 @@ describe("update", () => {
   it("does not modify update results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.update.query.mockImplementation(
@@ -42,6 +42,7 @@ describe("update", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -71,6 +72,7 @@ describe("update", () => {
           createValue: Boolean,
           allowToOneUpdates: true,
         },
+        rootDir,
       })
     );
 
@@ -103,6 +105,7 @@ describe("update", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -143,7 +146,7 @@ describe("update", () => {
   it("does not modify update when no args are passed", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     // @ts-expect-error - args are required
@@ -156,7 +159,7 @@ describe("update", () => {
   it("does not modify update when no where is passed", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     // @ts-expect-error - where is required

--- a/test/unit/updateMany.test.ts
+++ b/test/unit/updateMany.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("updateMany", () => {
   it("does not change updateMany action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.updateMany({
@@ -23,7 +23,7 @@ describe("updateMany", () => {
   it("does not modify updateMany results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.updateMany.query.mockImplementation(
@@ -41,14 +41,16 @@ describe("updateMany", () => {
   it("does not change updateMany action if args not passed", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     // @ts-expect-error - args are required
     await extendedClient.user.updateMany(undefined);
 
     // params have not been modified
-    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith(
+      undefined
+    );
   });
 
   it("excludes deleted records from root updateMany action", async () => {
@@ -56,6 +58,7 @@ describe("updateMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -79,6 +82,7 @@ describe("updateMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -100,6 +104,7 @@ describe("updateMany", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Comment: true },
+        rootDir,
       })
     );
 
@@ -153,6 +158,7 @@ describe("updateMany", () => {
         models: {
           User: true,
         },
+        rootDir,
       })
     );
 
@@ -181,6 +187,7 @@ describe("updateMany", () => {
             },
           },
         },
+        rootDir,
       })
     );
 

--- a/test/unit/upsert.test.ts
+++ b/test/unit/upsert.test.ts
@@ -1,11 +1,11 @@
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("upsert", () => {
   it("does not modify upsert results", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { User: true } })
+      createSoftDeleteExtension({ models: { User: true }, rootDir })
     );
 
     extendedClient.user.upsert.query.mockImplementation(
@@ -30,6 +30,7 @@ describe("upsert", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -51,6 +52,7 @@ describe("upsert", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 
@@ -86,6 +88,7 @@ describe("upsert", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { User: true },
+        rootDir,
       })
     );
 

--- a/test/unit/utils/mockClient.ts
+++ b/test/unit/utils/mockClient.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Prisma } from "@prisma/client";
 
 type DelegateByModel<Model extends Prisma.ModelName> = Model extends "User"
@@ -87,6 +88,8 @@ function initModel(callbacks: Partial<{ [key in Operation]: jest.Mock }> = {}) {
     return acc;
   }, {});
 }
+
+export const rootDir = path.resolve(__dirname, "../..");
 
 export class MockClient {
   user: MockOperations<"User">;

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -1,13 +1,13 @@
 import faker from "faker";
 
 import { createSoftDeleteExtension } from "../../src";
-import { MockClient } from "./utils/mockClient";
+import { MockClient, rootDir } from "./utils/mockClient";
 
 describe("where", () => {
   it("does not change where action if model is not in the list", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: {} })
+      createSoftDeleteExtension({ models: {}, rootDir })
     );
 
     await extendedClient.user.deleteMany({
@@ -37,7 +37,7 @@ describe("where", () => {
   it("changes root where correctly when model is nested", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { Comment: true } })
+      createSoftDeleteExtension({ models: { Comment: true }, rootDir })
     );
 
     await extendedClient.user.deleteMany({
@@ -97,6 +97,7 @@ describe("where", () => {
     const extendedClient = client.$extends(
       createSoftDeleteExtension({
         models: { Post: true, Comment: true, User: true },
+        rootDir,
       })
     );
 
@@ -163,7 +164,7 @@ describe("where", () => {
   it("changes root where correctly when model is deeply nested", async () => {
     const client = new MockClient();
     const extendedClient = client.$extends(
-      createSoftDeleteExtension({ models: { Post: true } })
+      createSoftDeleteExtension({ models: { Post: true }, rootDir })
     );
 
     await extendedClient.user.deleteMany({
@@ -248,6 +249,7 @@ describe("where", () => {
           Comment: true,
           Post: true,
         },
+        rootDir,
       })
     );
 
@@ -315,6 +317,7 @@ describe("where", () => {
           Comment: true,
           Post: true,
         },
+        rootDir,
       })
     );
 
@@ -413,6 +416,7 @@ describe("where", () => {
         models: {
           Comment: true,
         },
+        rootDir,
       })
     );
 
@@ -453,6 +457,7 @@ describe("where", () => {
         models: {
           Comment: true,
         },
+        rootDir,
       })
     );
 
@@ -494,6 +499,7 @@ describe("where", () => {
           Comment: true,
           Post: true,
         },
+        rootDir,
       })
     );
 
@@ -543,6 +549,7 @@ describe("where", () => {
           Comment: true,
           Post: true,
         },
+        rootDir,
       })
     );
 


### PR DESCRIPTION
This implementation uses the `getDMMF` function from [`@prisma/internals`](https://www.npmjs.com/package/@prisma/internals).

The function works by passing the source prisma code, and then return the `dmmf` value of that source code.

This implementation get the `prisma.config.ts` file and get the schema files and feed them to the function. It uses something similar to the real Prisma approach to get the schema files, based on [this file](https://github.com/prisma/prisma/blob/bbd603e2ccb8f1f0bef33f53cf6575bd72757748/packages/config/src/loadConfigFromFile.ts).

https://github.com/olivierwilkinson/prisma-extension-soft-delete/pull/42#issuecomment-3698834716
#41

I want to show this as a possible way on how this can be achieve, not so much as the final product. I wasn't able to make the tests work, but I was able to make some manual tests on my own and the library was working